### PR TITLE
various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ Milua is inspired by frameworks like Flask or Express, so it just aims to be qui
 
 `examples/handsome_server.lua`
 ```lua
-local app = require "milua"
+local app = require("milua")
 
 -- Basic example
 app.add_handler(
     "GET",
     "/",
     function()
-        return "<h1>Welcome to the handsome server!</h1>"
+        return "<h1>Welcome to the <i>handsome</i> server!</h1>", {
+            ["Content-Type"] = "text/html"
+        }
     end
 )
 
@@ -36,11 +38,18 @@ app.add_handler(
     "GET",
     "/user/...", 
     function (captures, query, headers)
-
         local username = captures[1]
         local times = query.times or 1
         return "The user " .. username .. " is" .. (" very"):rep(times) .. " handsome"
-    
+    end
+)
+
+-- Example returning no data and status
+app.add_handler(
+    "DELETE",
+    "/user",
+    function ()
+        return nil, { [":status"] = "204" }
     end
 )
 

--- a/examples/handsome_server.lua
+++ b/examples/handsome_server.lua
@@ -1,11 +1,13 @@
-local app = require("../src")
+local app = require("milua")
 
 -- Basic example
 app.add_handler(
     "GET",
     "/",
     function()
-        return "<h1>Welcome to the handsome server!</h1>"
+        return "<h1>Welcome to the <i>handsome</i> server!</h1>", {
+            ["Content-Type"] = "text/html"
+        }
     end
 )
 
@@ -14,11 +16,18 @@ app.add_handler(
     "GET",
     "/user/...", 
     function (captures, query, headers)
-
         local username = captures[1]
         local times = query.times or 1
         return "The user " .. username .. " is" .. (" very"):rep(times) .. " handsome"
-    
+    end
+)
+
+-- Example returning no data and status
+app.add_handler(
+    "DELETE",
+    "/user",
+    function ()
+        return nil, { [":status"] = "204" }
     end
 )
 


### PR DESCRIPTION
Hey, I am implementing a microservice for a small hobby project and I came across some issues which I would like to contribute back:

- `res_headers:upsert` has to be used in combination with `string.lower(key)` to set headers and prevent adding duplicates
- some minor bugfixes:
  - typo
  - "Not Found" status was a number (instead of a string) and also not 404
- removed some unnecessary whitespace for logging
- make it possible to respond without body
- default `content-type` should not be set as it depends on the use case
- add defaults for host and port
- extended example

I hope you can agree with all of the suggestions, if not, please ping me and I can remove them.