### PR TITLE
Adding shutdown_hook to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ app.add_handler(
     end
 )
 
+-- Hooking the server close event
+app.shutdown_hook(function()
+    -- cleaning up any external resource
+end)
+
 app.start()
 ```
 You can run the example directly:
@@ -84,6 +89,8 @@ Right now the `milua` module only offers:
     - and must return the following values:
         - The body of the repsonse.
         - (Optional) A table with the headers of the response.
+
+- `shutdown_hook(func)` where `func` is a function which will be called before closing the server.
 
 - `start(config)` where `config` contains the `host` and the `port` to run the application.
 - `logger` table with support for INFO, DEBUG, and ERROR logging levels

--- a/src/milua.lua
+++ b/src/milua.lua
@@ -134,6 +134,9 @@ local function onerror(myserver, context, op, err, errno) -- luacheck: ignore 21
         logger.ERROR(msg)
     end
 
+-- no-op function by default
+local onshutdown = function() return nil end
+
 function app.start(config)
     config = config or {}
     local myserver = assert(http_server.listen {
@@ -159,6 +162,7 @@ function app.start(config)
     -- https://stackoverflow.com/questions/32337591/how-catch-ctrl-c-in-lua-when-ctrl-c-is-sent-via-the-command-line#34409274
     signal.signal(signal.SIGINT, function(signum)
         logger.INFO("Shuting down server")
+        onshutdown()
         myserver:close()
         logger.INFO("BYE!!")
         os.exit(128 + signum)
@@ -166,6 +170,11 @@ function app.start(config)
 
     -- Start the main server loop
     assert(myserver:loop())
+end
+
+function app.shutdown_hook(func)
+    assert(type(func) == "function", "parameter to shutdown_hook must be a function")
+    onshutdown = func
 end
 
 return app


### PR DESCRIPTION
This PR contains a few changes in order to add a way for the user of this library to configure a function to be executed before we close the server, so he/she can clear external resources like closing database connection.

📓 Changes
- Adds documentation of the new `shutdown_hook` method to README
- Adds the method `shutdown_hook` method to the `app` type.

Does that make sense?